### PR TITLE
Add ZD_Pk_sigma_ratio and ZD_f_cluster parameters

### DIFF
--- a/output.cpp
+++ b/output.cpp
@@ -60,7 +60,18 @@ BlockArray& array, Parameters& param) {
     // No care has been paid to the normalization of the velocity;
     // this is simply the displacement field.  However, this does happen
     // to be v/H, which is correct for the redshift-space displacement in EdS
-    norm = 1.0; densitynorm = 1.0; vnorm = param.f_growth;
+    norm = 1.0; densitynorm = 1.0;
+    
+    // We may also need to apply an f_growth factor to the velocities
+    // from the addition of a smooth, non-clustering background component
+    // (indicated by f_cluster != 1)
+    // If we used PLT, then we took care of this while computing
+    // the PLT growth rate effects.  If not, take care of it here.
+    if(param.qPLT){
+        vnorm = 1.0;
+    } else {
+        vnorm = (sqrt(1. + 24*param.f_cluster) - 1)*.25;
+    }
     //norm = 1e-2;
 
     int64_t i = 0;

--- a/output.cpp
+++ b/output.cpp
@@ -60,7 +60,7 @@ BlockArray& array, Parameters& param) {
     // No care has been paid to the normalization of the velocity;
     // this is simply the displacement field.  However, this does happen
     // to be v/H, which is correct for the redshift-space displacement in EdS
-    norm = 1.0; densitynorm = 1.0; vnorm = 1.0;
+    norm = 1.0; densitynorm = 1.0; vnorm = param.f_growth;
     //norm = 1e-2;
 
     int64_t i = 0;

--- a/parameters.cpp
+++ b/parameters.cpp
@@ -23,7 +23,7 @@ public:
     double Pk_norm;    // The scale to normalize P(k) at, in simulation units!
     double Pk_sigma;    // The normalization at that scale, at the initial redshift!
     double Pk_sigma_ratio;    // An alternative to Pk_sigma: a ratio by which to normalize, instead of a target amplitude
-    double f_growth;  // The logarithmic derivative of the growth factor.  Used to set the velocities.  Should be 1 in matter domination, probably less than 1 for neutrinos
+    double f_cluster;  // The fraction of the matter that is clustering.  Usually 1 without neutrinos, and 1 - Omega_Smooth/Omega_M with.
     double Pk_smooth;    // The scale to smooth P(k) at, in simulation units!
     int qPk_fix_to_mean;    // Don't draw the mode amplitude from a Gaussian; use sqrt(P(k)) instead.
     char Pk_filename[200];   // The file name for the P(k) input
@@ -71,7 +71,7 @@ public:
         Pk_norm = 0;    // Legal default: Don't renormalize the power spectrum
         Pk_sigma = 0;    // Legal default, but you probably don't want this!
         Pk_sigma_ratio = 0;    // Legal default
-        f_growth = 1;  // Legal default
+        f_cluster = 1;  // Legal default
         Pk_smooth = 0;    // Legal default
         qPk_fix_to_mean = 0; // Legal default
         seed = 0;    // Legal default
@@ -126,7 +126,7 @@ public:
         installscalar("ZD_Pk_norm",Pk_norm,MUST_DEFINE);
         installscalar("ZD_Pk_sigma",Pk_sigma,DONT_CARE);
         installscalar("ZD_Pk_sigma_ratio",Pk_sigma_ratio,DONT_CARE);
-        installscalar("ZD_f_growth",f_growth,DONT_CARE);
+        installscalar("ZD_f_cluster",f_cluster,DONT_CARE);
         installscalar("ZD_Pk_smooth",Pk_smooth,MUST_DEFINE);
         installscalar("ZD_qPk_fix_to_mean",qPk_fix_to_mean,DONT_CARE);
         installscalar("ZD_Pk_filename",Pk_filename,DONT_CARE);
@@ -202,7 +202,7 @@ int Parameters::setup() {
         exit(1);
     }
 
-    assert(f_growth > 0);  // Non-positive is legal, but most likely not desired
+    assert(f_cluster > 0. && f_cluster <= 1.);  // Anything outside this range is probably a bug
 
     // Must specify exactly one of Pk file or power law index
     assert( (bool)(strlen(Pk_filename) > 0) != (bool) !std::isnan(Pk_powerlaw_index) );

--- a/parameters.cpp
+++ b/parameters.cpp
@@ -22,6 +22,8 @@ public:
     int seed;    // Random number seed
     double Pk_norm;    // The scale to normalize P(k) at, in simulation units!
     double Pk_sigma;    // The normalization at that scale, at the initial redshift!
+    double Pk_sigma_ratio;    // An alternative to Pk_sigma: a ratio by which to normalize, instead of a target amplitude
+    double f_growth;  // The logarithmic derivative of the growth factor.  Used to set the velocities.  Should be 1 in matter domination, probably less than 1 for neutrinos
     double Pk_smooth;    // The scale to smooth P(k) at, in simulation units!
     int qPk_fix_to_mean;    // Don't draw the mode amplitude from a Gaussian; use sqrt(P(k)) instead.
     char Pk_filename[200];   // The file name for the P(k) input
@@ -68,6 +70,8 @@ public:
         qoneslab = -1;    // Legal default
         Pk_norm = 0;    // Legal default: Don't renormalize the power spectrum
         Pk_sigma = 0;    // Legal default, but you probably don't want this!
+        Pk_sigma_ratio = 0;    // Legal default
+        f_growth = 1;  // Legal default
         Pk_smooth = 0;    // Legal default
         qPk_fix_to_mean = 0; // Legal default
         seed = 0;    // Legal default
@@ -120,7 +124,9 @@ public:
         installscalar("ZD_qoneslab",qoneslab,DONT_CARE);
         installscalar("ZD_Seed",seed,MUST_DEFINE);
         installscalar("ZD_Pk_norm",Pk_norm,MUST_DEFINE);
-        installscalar("ZD_Pk_sigma",Pk_sigma,MUST_DEFINE);
+        installscalar("ZD_Pk_sigma",Pk_sigma,DONT_CARE);
+        installscalar("ZD_Pk_sigma_ratio",Pk_sigma_ratio,DONT_CARE);
+        installscalar("ZD_f_growth",f_growth,DONT_CARE);
         installscalar("ZD_Pk_smooth",Pk_smooth,MUST_DEFINE);
         installscalar("ZD_qPk_fix_to_mean",qPk_fix_to_mean,DONT_CARE);
         installscalar("ZD_Pk_filename",Pk_filename,DONT_CARE);
@@ -190,7 +196,14 @@ int Parameters::setup() {
     assert(! (numblock<=0) );
     assert(! (Pk_scale<=0.0) );
     assert(! (Pk_norm<0.0) );
-    assert(! (Pk_sigma<0.0) );
+
+    if((bool)(Pk_sigma > 0) == (bool)(Pk_sigma_ratio > 0)){
+        fprintf(stderr, "Must specify exactly one of Pk_sigma or Pk_sigma_ratio!\n");
+        exit(1);
+    }
+
+    assert(f_growth > 0);  // Non-positive is legal, but most likely not desired
+
     // Must specify exactly one of Pk file or power law index
     assert( (bool)(strlen(Pk_filename) > 0) != (bool) !std::isnan(Pk_powerlaw_index) );
     if(!std::isnan(Pk_powerlaw_index))

--- a/power_spectrum.cpp
+++ b/power_spectrum.cpp
@@ -133,8 +133,17 @@ public:
         // Might still have to normalize things!
         if (param.Pk_norm>0.0) { // Do a normalization 
             fprintf(stderr,"Input sigma(%f) = %f\n", param.Pk_norm, sigmaR(param.Pk_norm));
-            normalization = param.Pk_sigma/sigmaR(param.Pk_norm);
-            normalization *= normalization;
+
+            if(param.Pk_sigma > 0){
+                normalization = param.Pk_sigma/sigmaR(param.Pk_norm);
+                normalization *= normalization;
+            } else if (param.Pk_sigma_ratio > 0) {
+                normalization = param.Pk_sigma_ratio*param.Pk_sigma_ratio;
+            }
+            else{
+                assert(param.Pk_sigma > 0 || param.Pk_sigma_ratio > 0);  // Illegal state! We checked this in the params
+            }
+
             fprintf(stderr,"Final sigma(%f) = %f\n", param.Pk_norm, sigmaR(param.Pk_norm));
         }
         // Might need to normalize to the box volume.  This is appropriate

--- a/zeldovich.cpp
+++ b/zeldovich.cpp
@@ -326,8 +326,14 @@ void LoadPlane(BlockArray& array, Parameters& param, PowerSpectrum& Pk,
                 G = rescale*I*e.vec[1]/k2*D;
                 H = rescale*I*e.vec[2]/k2*D;
                 
-                if(param.qPLT)
-                    f = (sqrt(1. + 24*e.val) - 1)*.25; // 1/4 instead of 1/6 because v = alpha*u/t0 = 3/2*H*alpha*u
+                if(param.qPLT){
+                    // This is f_growth, the logarithmic derivative of the growth factor that scales the velocities
+                    // The corrections are sourced from:
+                    // 1) PLT growth rate
+                    // 2) Addition of a smooth, non-clustering component to the background (<= NOT A PLT EFFECT)
+                    // If PLT is turned on, we have to combine the effects here.  If not, we apply f_cluster during output.
+                    f = (sqrt(1. + 24*e.val*param.f_cluster) - 1)*.25; // 1/4 instead of 1/6 because v = alpha*u/t0 = 3/2*H*alpha*u
+                }
             } else {
                 F = G = H = f = 0.;
             }

--- a/zeldovich.cpp
+++ b/zeldovich.cpp
@@ -319,8 +319,11 @@ void LoadPlane(BlockArray& array, Parameters& param, PowerSpectrum& Pk,
                 if(param.qPLTrescale){
                     double a_NL = 1./(1+param.PLT_target_z);
                     double a0 = 1./(1+param.z_initial);
-                    double alpha_m = (sqrt(1. + 24*e.val) - 1)/6.;
-                    rescale = pow(a_NL/a0, 1 - 1.5*alpha_m);
+                    // First is continuum linear theory growth rate, possibly including f_smooth
+                    // Second is PLT growth rate, also including f_smooth
+                    double target_f = (sqrt(1. + 24*param.f_cluster) - 1)/4.;
+                    double plt_f = (sqrt(1. + 24*e.val*param.f_cluster) - 1)/4.;
+                    rescale = pow(a_NL/a0, target_f - plt_f);
                 }
                 F = rescale*I*e.vec[0]/k2*D;
                 G = rescale*I*e.vec[1]/k2*D;


### PR DESCRIPTION
Add support for setting the power spectrum amplitude via a growth ratio rather than a target amplitude via the `ZD_Pk_sigma_ratio` parameter.  Also allows modifying the velocities via the `ZD_f_cluster` parameter that indicates the fraction of the matter that is clustering (i.e. f_cluster = 1 - Omega_Smooth/Omega_M).